### PR TITLE
Added: Falling back to AllocMem when Used Memory is < 0 or FreeMem = N/A (Made during my internship at CEA)

### DIFF
--- a/da/rms/SLURM/slurm.py
+++ b/da/rms/SLURM/slurm.py
@@ -302,7 +302,7 @@ def nodeinfo(options: dict, nodes_info) -> dict:
     UsedMem = None
 
     if not (re.match(r'^\d+$',nodeinfo['FreeMem'])): #.e.g FreeMem=N/A
-      log.warning(f"FreeMem might be N/A, falling back to AllocMem \n")
+      log.warning(f"FreeMem {nodeinfo['FreeMem']} not an integer for node {nodename}, falling back to AllocMem \n")
 
     elif (re.match(r'^\d+$',nodeinfo['RealMemory'])) and (re.match(r'^\d+$',nodeinfo['FreeMem'])):
 


### PR DESCRIPTION
Hello,

I’ve thought of an additional check for `slurm.py`. In some cases, it’s possible to encounter clusters where `FreeMem = N/A` or, in containerized environments, cases where `RealMemory < FreeMem`.

I think that falling back to `AllocMem` before using `continue` might be better.