### PR TITLE
Fix: CINODES_BY_NODEID sanitizing for core info

### DIFF
--- a/da/LML_DBupdate/LML_DBupdate_adapt.pm
+++ b/da/LML_DBupdate/LML_DBupdate_adapt.pm
@@ -7,6 +7,7 @@
 #
 # Contributors:
 #    Wolfgang Frings (Forschungszentrum Juelich GmbH) 
+#    Matthias Lapu (CEA)
 
 package LML_DBupdate_file;
 


### PR DESCRIPTION
Hello, 

I have found a way to fix my issue. After reviewing `LML_DBupdate_adapt.pm`, I noticed that the values in `CINODES_BY_NODEID` included the port, whereas `nodeid` didn't. This probably has to do with how I did my implementation; I honestly do not know why.

I tried to fix this without changing the core logic of the code, thinking that if this is a mistake in my implementation, others might make the same one.

There has to be a better way to handle this, or at least a more efficient one. I’m not very proficient in Perl.


I added some print statements during my debugging phase to illustrate this:

```
root@server logs]# cat dbupdate.2025.11.06.errlog 
CINODES_BY_NODEID keys: c1:9100, c3:9100, c2:9100
Checking nodeid=c1
CINODES_BY_NODEID keys: c1:9100, c3:9100, c2:9100
Checking nodeid=c3
```