### PR TITLE
Adding a docker image for jureptool

### DIFF
--- a/jureptool/Dockerfile
+++ b/jureptool/Dockerfile
@@ -1,0 +1,20 @@
+# author : Matthias Lapu (CEA)
+FROM python:3.11-slim
+
+WORKDIR /jureptool
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY src src/
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        fonts-liberation \
+        fontconfig && \
+        fc-cache -f -v && \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT [ "python3", "src/main.py" ]

--- a/jureptool/README.md
+++ b/jureptool/README.md
@@ -94,6 +94,21 @@ rm -fr ~/.cache/matplotlib
 ```
 (on MacOs, matplotlib's cache folder is `~/.matplotlib`.)
 
+### Docker
+
+A Docker image is provided to run Jureptool. Jureptool requires access to the config folder and the file argument.
+
+You will need to pass these arguments using mounted volumes in Docker. See the example below :
+```sh
+# pwd = llview/jureptool
+docker build -t jureptool .
+
+docker run \
+  -v $(pwd)/configs:/jureptool/configs \
+  -v $(pwd)/folder:/jureptool/folder \
+  jureptool --configfolder configs folder
+```
+
 
 ### Expected file
 

--- a/jureptool/requirements.txt
+++ b/jureptool/requirements.txt
@@ -1,0 +1,7 @@
+matplotlib>=3.5.0,<4.0.0
+numpy
+pandas
+pyyaml
+plotly
+cmcrameri
+requests


### PR DESCRIPTION
Hello,

I wanted to add a Docker image for jureptool. I’m not sure whether a containerized approach aligns with what you’re envisioning for llview, but I think that parts of it, such as jureptool, could absolutely work as a service.

Providing a Docker image could therefore be tremendously helpful, especially with #16 & #17.

I also updated the README.md with guidelines on how to build and run the image.